### PR TITLE
Fix podspec error

### DIFF
--- a/ios/RNBackwardPlantnet.podspec
+++ b/ios/RNBackwardPlantnet.podspec
@@ -4,9 +4,9 @@ Pod::Spec.new do |s|
   s.version      = "1.0.0"
   s.summary      = "RNBackwardPlantnet"
   s.description  = <<-DESC
-                  RNBackwardPlantnet
+                  Provide migration utility from PlantNet mobile app v2 (native) to v3. 
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/floristic-project/react-native-backward-plantnet"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
issue: 
```
[!] The `RNBackwardPlantnet` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```

This should hopefully fix this (2/3)